### PR TITLE
Us15 linkar monitoria ao perfil

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     environment:
       - REACT_APP_PATH_KEY=${REACT_APP_PATH_KEY}
       - REACT_APP_AUTH=${REACT_APP_AUTH}
-      - REACT_APP_URL=${REACT_APP_URL}
+      - REACT_APP_GATEWAY=${REACT_APP_GATEWAY}
     networks:
       - api-backend
     tty: true  

--- a/src/Components/Profile/Profile.js
+++ b/src/Components/Profile/Profile.js
@@ -26,10 +26,7 @@ class Profile extends Component {
         name:'',
         course: '',
         email: '',
-        nameMonitoring: 'Derivada',
-        subject: 'Cálculo 1',
-        description: 'Aula sobre derivadas.',
-        monitor: 'Batatinha'
+        monitoring: []
     }
     
 
@@ -44,7 +41,7 @@ class Profile extends Component {
               
                 axios.post(process.env.REACT_APP_GATEWAY+"/get_user/", token).then(user=>{
                     userData = user.data;
-                    this.setState({name:userData["name"],course:userData["course"]}) 
+                    this.setState({name:userData["name"], course:userData["course"], monitoring:userData["monitoring"]}) 
                 });  
             }     
         })
@@ -87,9 +84,13 @@ class Profile extends Component {
                         <Grid item xs={12} style={{marginTop:10}}>
                             <ProfileTab/>
                         </Grid>
-                        <Grid item lg={12} sm={12} container style={{paddingTop:20}} >
-                            <Card name_monitoring={this.state.nameMonitoring} matter={this.state.subject} monitor={this.state.monitor} deion={this.state.description}/>
-                        </Grid>
+                        {this.state.monitoring.map(function(item, i){
+                            return (
+                                <Grid item key={i} lg={12} sm={12} container >
+                                    <Card name_monitoring={item.name} matter={item.subject} deion={item.description}/>
+                                </Grid>
+                            );
+                        })}
                     </Grid>
                 </div>
             </div>

--- a/src/Components/__tests__/__snapshots__/Login.test.js.snap
+++ b/src/Components/__tests__/__snapshots__/Login.test.js.snap
@@ -3,6 +3,12 @@
 exports[`Testing Login component Test if Login renders correctly 1`] = `
 <div
   className="LoginBackground"
+  style={
+    Object {
+      "overflowX": "hidden",
+      "overflowY": "auto",
+    }
+  }
 >
   <WithStyles(Grid)
     alignContent="center"

--- a/src/Components/__tests__/__snapshots__/RegisterMonitoring.test.js.snap
+++ b/src/Components/__tests__/__snapshots__/RegisterMonitoring.test.js.snap
@@ -61,76 +61,6 @@ exports[`Testing RegisterMonitoring component Test if RegisterMonitoring renders
       </WithStyles(Grid)>
       <WithStyles(Grid)
         item={true}
-      >
-        <WithStyles(Grid)
-          alignContent="center"
-          alignItems="center"
-          container={true}
-          direction="row"
-          justify="center"
-          spacing={16}
-        >
-          <WithStyles(Grid)
-            item={true}
-            md-auto={true}
-          >
-            <TextField
-              InputLabelProps={
-                Object {
-                  "shrink": true,
-                }
-              }
-              id="InicioTexfild"
-              label="Inicio"
-              margin="normal"
-              required={false}
-              select={false}
-              type="time"
-              variant="standard"
-            />
-          </WithStyles(Grid)>
-          <WithStyles(Grid)
-            item={true}
-            md-auto={true}
-          >
-            <TextField
-              InputLabelProps={
-                Object {
-                  "shrink": true,
-                }
-              }
-              id="terminoTexfild"
-              label="Termino"
-              margin="normal"
-              required={false}
-              select={false}
-              type="time"
-              variant="standard"
-            />
-          </WithStyles(Grid)>
-        </WithStyles(Grid)>
-      </WithStyles(Grid)>
-      <WithStyles(Grid)
-        item={true}
-        md-auto={true}
-      >
-        <TextField
-          InputLabelProps={
-            Object {
-              "shrink": true,
-            }
-          }
-          defaultValue="00-00-0000"
-          id="date"
-          label="Data"
-          required={false}
-          select={false}
-          type="date"
-          variant="standard"
-        />
-      </WithStyles(Grid)>
-      <WithStyles(Grid)
-        item={true}
         md-auto={true}
       >
         <TextField
@@ -163,7 +93,9 @@ exports[`Testing RegisterMonitoring component Test if RegisterMonitoring renders
         >
           <WithStyles(Button)
             color="primary"
+            component={[Function]}
             onClick={[Function]}
+            to="/Feed"
             variant="outlined"
           >
             Registrar


### PR DESCRIPTION
## Issue resolvida

[[US15] "Linkar" Monitoria ao Perfil do Usuário que a Criou](https://github.com/fga-eps-mds/2019.1-MaisMonitoria/issues)

## Comentário

Para exibir as monitorias ofertadas por o usuário na tela do seu perfil foi utilizada uma abordagem parecida com a utilizada na tela do feed, que foi possível graças as alterações realizadas no backend. A abordagem consiste em salvar os dados das monitorias provenientes da requisição, em uma lista e utilizar um map para criação dos cards. 

![request](https://user-images.githubusercontent.com/31708472/57658196-64f74300-75b4-11e9-89c6-cd20280bdb50.png)
Salvamento dos dados da requisição.

![card](https://user-images.githubusercontent.com/31708472/57658213-73455f00-75b4-11e9-80d2-f7c296b0e7c3.png)
Utilização do map para criação dos cards.

![tela-perfil](https://user-images.githubusercontent.com/31708472/57658235-8bb57980-75b4-11e9-8de1-5e154cee9d31.jpeg)
Resuldado das alterações.
