### PR TITLE
Ts19 limitar requisicoes

### DIFF
--- a/src/Components/Feed/Feed.js
+++ b/src/Components/Feed/Feed.js
@@ -17,13 +17,72 @@ import _ from 'lodash';
 
 
 class TelaFeed extends Component {
-    state =  {
-        data : [],
-        showWarning: false,
-        isLoading: false
-    }
+   
+    constructor(props) {
+        super(props);
+        this.state = {
+            data : [],
+            showWarning: false,
+            isLoading: false,
+            next: '',
+            previous: null,
+            page : 2
+        };
+
+        window.onscroll = () => {         
+          if (document.documentElement.scrollHeight-document.documentElement.scrollTop===document.documentElement.clientHeight) {
+            
+            this.loadMore()
+            
+          }
+        };
+      }
+    
+    loadMore(){
+        setTimeout(function() { 
+            
+        console.log("yes")
+            const next = this.state.next;
+            console.log(next)
+            if(next != null){
+                console.log("yestt")
+                const page= this.state.page;
+                var token = {};
+
+                this.setState({ isLoading: true });
+                firebase.auth().onAuthStateChanged(user =>{
+                    this.setState({isSignedIn: !!user});
+                    if(user){
+                        firebase.auth().currentUser.getIdToken().then(function(idToken){
+                            token["access_token"] = idToken;
+                        });
+                        // axios.post(process.env.REACT_APP_GATEWAY+`/all_tutoring/?page=${page}`, token)
+                        //     .then(res => {
+                        //         const prox = null;
+                        //         const ante = res.data.previous;
+                        //         const person = res.data.results;
+                        //         console.log(person);
+                        //         this.setState({data:[...this.state.data,...person],next:prox,previous:ante});
+                                
+                        //         if(prox!= null){
+                        //             page= page +1;
+                        //             this.setState({page:page});
+                        //         }
+                        //     });
+                    }
+                    else{
+                        this.props.history.push('/');
+                    }
+                });
+            
+            
+            
+            }
+        }.bind(this), 500)
+      };
 
     componentDidMount() {
+       
         var token = {};
 
         this.setState({ isLoading: true });
@@ -35,8 +94,11 @@ class TelaFeed extends Component {
                 });
                 axios.post(process.env.REACT_APP_GATEWAY+"/all_tutoring/", token)
                     .then(res => {
-                        const person = res.data.results
-                        this.setState({data:person})
+                        const pages = res.data.next;
+                        const ante = res.data.previous;
+                        const person = res.data.results;
+                        this.setState({data:person,next:pages,previous:ante});
+                        console.log(this.state.next)
                     });
                 this.setState({ isLoading: false });
             }
@@ -45,9 +107,14 @@ class TelaFeed extends Component {
             }
         });
     }
+   
+
+    
+   
 
   render() {  
     return (
+             
         <div style={{overflowX:'hidden'}} className="FeedBackground">
             <Grid style={{position: "absolute"}} container justify="center" alignItems="stretch">
                 <AppBar/>    
@@ -78,6 +145,7 @@ class TelaFeed extends Component {
                 }
             </Grid>
         </div>
+        
     );   
   }
 }

--- a/src/Components/Feed/Feed.js
+++ b/src/Components/Feed/Feed.js
@@ -26,7 +26,7 @@ class TelaFeed extends Component {
             next: '',
             page : 2,
             endlist:false,
-            aux : true
+            aux : false
         };
 
         window.onscroll = () => {         

--- a/src/Components/Feed/Feed.js
+++ b/src/Components/Feed/Feed.js
@@ -14,8 +14,6 @@ import Tab from '../Tab/Tab';
 import {withRouter} from 'react-router-dom';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
-import InfiniteLoader from 'react-infinite-loader'
-import ReactDOM from 'react-dom'
 
 
 class TelaFeed extends Component {

--- a/src/Components/Feed/Feed.js
+++ b/src/Components/Feed/Feed.js
@@ -26,7 +26,9 @@ class TelaFeed extends Component {
             isLoading: false,
             next: '',
             previous: null,
-            page : 2
+            page : 2,
+            endlist:false,
+            aux:false
         };
 
         window.onscroll = () => {         
@@ -40,50 +42,56 @@ class TelaFeed extends Component {
     
     loadMore(){
         setTimeout(function() { 
-            
-        console.log("yes")
-            const next = this.state.next;
-            console.log(next)
-            if(next != null){
-                console.log("yestt")
-                const page= this.state.page;
-                var token = {};
+            console.log("yes")
+                const next = this.state.next;
+                if(next != null){
+                    console.log("yestt")
+                    const page= this.state.page;
+                    var token = {
+                        page:''
+                    };
 
-                this.setState({ isLoading: true });
-                firebase.auth().onAuthStateChanged(user =>{
-                    this.setState({isSignedIn: !!user});
-                    if(user){
-                        firebase.auth().currentUser.getIdToken().then(function(idToken){
-                            token["access_token"] = idToken;
-                        });
-                        // axios.post(process.env.REACT_APP_GATEWAY+`/all_tutoring/?page=${page}`, token)
-                        //     .then(res => {
-                        //         const prox = null;
-                        //         const ante = res.data.previous;
-                        //         const person = res.data.results;
-                        //         console.log(person);
-                        //         this.setState({data:[...this.state.data,...person],next:prox,previous:ante});
-                                
-                        //         if(prox!= null){
-                        //             page= page +1;
-                        //             this.setState({page:page});
-                        //         }
-                        //     });
-                    }
-                    else{
-                        this.props.history.push('/');
-                    }
-                });
-            
-            
-            
-            }
-        }.bind(this), 500)
+                    this.setState({ isLoading: true });
+                    firebase.auth().onAuthStateChanged(user =>{
+                        this.setState({isSignedIn: !!user});
+                        if(user){
+                            firebase.auth().currentUser.getIdToken().then(function(idToken){
+                                token["access_token"] = idToken;
+                            });
+                            token["page"]= this.state.page;
+                            axios.post(process.env.REACT_APP_GATEWAY+"/all_tutoring/", token)
+                                .then(res => {
+                                    const prox = res.data.next;
+                                    const ante = res.data.previous;
+                                    const person = res.data.results;
+                                    this.setState({data:[...this.state.data,...person],next:prox,previous:ante});
+
+                                    if(prox!= null){
+                                        page= page +1;
+                                        this.setState({page:page});
+                                    }
+                                    else{
+                                        this.setState({endlist:true})
+                                    }
+                                });
+                        }
+                        else{
+                            this.props.history.push('/');
+                        }
+                    });
+                
+                
+                
+                }
+        }.bind(this), 1500)
+        this.setState({ isLoading: false });
       };
 
     componentDidMount() {
        
-        var token = {};
+        var token = {
+            page:''
+        };
 
         this.setState({ isLoading: true });
         firebase.auth().onAuthStateChanged(user =>{
@@ -92,6 +100,7 @@ class TelaFeed extends Component {
                 firebase.auth().currentUser.getIdToken().then(function(idToken){
                     token["access_token"] = idToken;
                 });
+
                 axios.post(process.env.REACT_APP_GATEWAY+"/all_tutoring/", token)
                     .then(res => {
                         const pages = res.data.next;
@@ -128,8 +137,11 @@ class TelaFeed extends Component {
                                     description={item.description} photo={item.monitor.photo} 
                                     monitorName={item.monitor.name} id_tutoring={item.id_tutoring_session} />
                             </Grid>
+
                         );
-                    })}
+
+                    })}                  
+                    {this.state.endlist?<h4>Não há mais monitorias</h4>:null}
                 </Grid>
                 <Tab ind={0}/>
             </div>

--- a/src/Components/Feed/Feed.js
+++ b/src/Components/Feed/Feed.js
@@ -14,6 +14,8 @@ import Tab from '../Tab/Tab';
 import {withRouter} from 'react-router-dom';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
+import InfiniteLoader from 'react-infinite-loader'
+import ReactDOM from 'react-dom'
 
 
 class TelaFeed extends Component {
@@ -35,7 +37,7 @@ class TelaFeed extends Component {
                 });
                 axios.post(process.env.REACT_APP_GATEWAY+"/all_tutoring/", token)
                     .then(res => {
-                        const person = res.data
+                        const person = res.data.results
                         this.setState({data:person})
                     });
                 this.setState({ isLoading: false });

--- a/src/Components/Search/Search.js
+++ b/src/Components/Search/Search.js
@@ -59,7 +59,7 @@ class Search extends Component {
                 });
             axios.post(process.env.REACT_APP_GATEWAY+"/search_tutoring/", token)
             .then(res => {
-                let person = res.data
+                let person = res.data.results
                 this.setState({data:person})
                  });                                           
     }


### PR DESCRIPTION
## Issue resolvida

#TS19 - [Limitar requisições no feed] (https://github.com/fga-eps-mds/2019.1-MaisMonitoria/issues/160)

Foi implementado no Componente Feed um construtor com a função window.onscroll, responsável por acionar a função de requisição da pagina seguinte, na Api monitorias, quando o scroll chega ao fim, trazendo um conjunto limitado de monitorias.  

Construtor com window.scroll:
![image](https://user-images.githubusercontent.com/48539765/59234112-b863ad80-8bc1-11e9-854e-10eff4bcbedb.png)

A função loadMore realiza a requisição da próxima pagina caso exista:
![image](https://user-images.githubusercontent.com/48539765/59234243-42ac1180-8bc2-11e9-9d54-154d2d0224ed.png)

Ao iniciar a requisição de mais monitorias o componente Spinner é acionado, finalizando sua ação ao término da requisição.

![image](https://user-images.githubusercontent.com/48539765/59234581-d9c59900-8bc3-11e9-87b1-d94775a1952e.png)

Quando a lista de monitorias chega ao fim(ultima página da Api Monitorias)  é exibida uma mensagem:

![image](https://user-images.githubusercontent.com/48539765/59234644-2610d900-8bc4-11e9-9fa7-46b563f9f919.png)






