### PR TITLE
REFACTOR-Campos criar / editar monitoria

### DIFF
--- a/src/Components/EditMonitoring/EditMonitoring.js
+++ b/src/Components/EditMonitoring/EditMonitoring.js
@@ -161,6 +161,7 @@ class EditMonitoring extends Component {
                 <Grid  item md-auto>
                     <TextField
                         error = {this.state.descriptionError}
+                        required = {true}
                         id="description"
                         label="Descrição"
                         placeholder=""

--- a/src/Components/EditMonitoring/EditMonitoring.js
+++ b/src/Components/EditMonitoring/EditMonitoring.js
@@ -11,6 +11,7 @@ import SimpleModal from '../SimpleModal';
 import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 import CustomizedSnackbars from '../SimpleModal/Snackbars';
 
+
 const theme = createMuiTheme({
     palette: {
       primary: { main: '#44a1f2' },
@@ -39,6 +40,7 @@ class EditMonitoring extends Component {
         nameError: '',
         subjectError: '',
         descriptionError: '',
+        
     }
 
     componentDidMount(){
@@ -135,34 +137,43 @@ class EditMonitoring extends Component {
             <Grid style={{paddingTop:150}} container alignContent="center" alignItems="center" justify="flex-end" direction="column" >
                 <Grid item md-auto>
                     <TextField
-                    error = {this.state.error}
+                    error = {this.state.nameError}
                     required= "true"
-                    id="temaTextField"
+                    id="name"
                     label="Tema"
-                    margin="normal"
-                    onChange={(event)=>this.setState({ ...this.state, monitoring: { ...this.state.monitoring, name: event.target.value } })}
+                    value={this.state.name}	
+                    onChange={(event)=>this.setState({	
+                        name: event.target.value,	
+                    })}
                     />
                 </Grid>
                 <Grid item md-auto>
                     <TextField
-                    error = {this.state.error}
+                    error = {this.state.subjectError}
                     required= "true"
-                    id="temaTextField"
+                    id="subject"
                     label="Matéria"
                     margin="normal"
-                    onChange={(event)=>this.setState({ ...this.state, monitoring: { ...this.state.monitoring, subject: event.target.value } })}
-                    />
+                    value={this.state.subject}	
+                    onChange={(event)=>this.setState({	
+                        subject: event.target.value,	
+                    })}                    />
                 </Grid>
                 <Grid  item md-auto>
                     <TextField
-                        id="descricaoTextfild"
+                        error = {this.state.descriptionError}
+                        id="description"
                         label="Descrição"
                         placeholder="Descrição"
                         multiline
                         margin="normal"
                         variant="outlined"
-                        onChange={(event)=>this.setState({ ...this.state, monitoring: { ...this.state.monitoring, description: event.target.value } })}
-                        />
+                        value = {this.state.description}
+                        onChange = {(event)=> this.setState({
+                            description: event.target.value,
+                        })}
+
+                    />
                     
                 </Grid>
             </Grid>

--- a/src/Components/EditMonitoring/EditMonitoring.js
+++ b/src/Components/EditMonitoring/EditMonitoring.js
@@ -166,7 +166,7 @@ class EditMonitoring extends Component {
                         placeholder=""
                         multiline
                         margin="normal"
-                        // variant="outlined"
+                        variant="outlined"
                         value={this.state.description}
                         onChange={(event)=>this.setState({
                             description: event.target.value,

--- a/src/Components/EditMonitoring/EditMonitoring.js
+++ b/src/Components/EditMonitoring/EditMonitoring.js
@@ -133,52 +133,37 @@ class EditMonitoring extends Component {
                 <AppBar/>
             </Grid>  
             <Grid style={{paddingTop:150}} container alignContent="center" alignItems="center" justify="flex-end" direction="column" >
-                <Grid item xs={12}> 
+                <Grid item md-auto>
                     <TextField
-                        error = {this.state.nameError}
-                        required= "true"
-                        id="name"
-                        label="Nome"
-                        multiline
-                        Maxrows="4"
-                        margin="normal"
-                        value={this.state.name}
-                        onChange={(event)=>this.setState({
-                            name: event.target.value,
-                        })}
+                    error = {this.state.error}
+                    required= "true"
+                    id="temaTextField"
+                    label="Tema"
+                    margin="normal"
+                    onChange={(event)=>this.setState({ ...this.state, monitoring: { ...this.state.monitoring, name: event.target.value } })}
                     />
                 </Grid>
-                <Grid item> 
+                <Grid item md-auto>
                     <TextField
-                        error = {this.state.subjectError}
-                        required= "true"
-                        id="subject"
-                        label="Matéria"
-                        multiline
-                        Maxrows="4"
-                        placeholder=""
-                        margin="normal"
-                        value={this.state.subject}
-                        onChange={(event)=>this.setState({
-                            subject: event.target.value,
-                        })}
+                    error = {this.state.error}
+                    required= "true"
+                    id="temaTextField"
+                    label="Matéria"
+                    margin="normal"
+                    onChange={(event)=>this.setState({ ...this.state, monitoring: { ...this.state.monitoring, subject: event.target.value } })}
                     />
                 </Grid>
-                <Grid item> 
+                <Grid  item md-auto>
                     <TextField
-                        error = {this.state.descriptionError}
-                        required= "true"
-                        id="description"
+                        id="descricaoTextfild"
                         label="Descrição"
+                        placeholder="Descrição"
                         multiline
-                        Maxrows="4"
-                        placeholder=""
                         margin="normal"
-                        value={this.state.description}
-                        onChange={(event)=>this.setState({
-                            description: event.target.value,
-                        })}
-                    />
+                        variant="outlined"
+                        onChange={(event)=>this.setState({ ...this.state, monitoring: { ...this.state.monitoring, description: event.target.value } })}
+                        />
+                    
                 </Grid>
             </Grid>
                 <Grid container style={{paddingTop:20}} alignContent="center" justify="center" direction="row" spacing={24} alignItems="center">

--- a/src/Components/Feed/ExpandedCard.js
+++ b/src/Components/Feed/ExpandedCard.js
@@ -262,7 +262,7 @@ class ExpandedCard extends React.Component {
                     </MuiThemeProvider>}
               </Grid>
               <Grid item>
-                    <a href={"https://t.me/" + texto} target="_blank">{
+                    <a href={"https://t.me/" + texto} target="_blank"  rel="noopener noreferrer">{
                         <MuiThemeProvider theme={theme}>
                             <Fab color="primary" aria-label="Edit" >
                                 <Logo/>

--- a/src/Components/Feed/ExpandedCard.js
+++ b/src/Components/Feed/ExpandedCard.js
@@ -254,7 +254,7 @@ class ExpandedCard extends React.Component {
                     </MuiThemeProvider>}
               </Grid>
               <Grid item>
-                    <a href={"https://t.me/" + texto}>{
+                    <a href={"https://t.me/" + texto} target="_blank">{
                         <MuiThemeProvider theme={theme}>
                             <Fab color="primary" aria-label="Edit" >
                                 <Logo/>

--- a/src/Components/ProfileMonitor/ProfileMonitor.js
+++ b/src/Components/ProfileMonitor/ProfileMonitor.js
@@ -146,7 +146,7 @@ class Profile extends Component {
                                                 <h2>{this.state.monitorName}</h2>
                                             </Grid>
                                             <Grid item > 
-                                                <a href={"https://t.me/" + texto}>{
+                                                <a href={"https://t.me/" + texto} target="_blank"  rel="noopener noreferrer">{
                                                     <MuiThemeProvider theme={theme}>
                                                         <Fab size="small" color="primary" aria-label="Edit" >
                                                             <Logo/>

--- a/src/Components/RegisterMonitoring/RegisterMonitoring.js
+++ b/src/Components/RegisterMonitoring/RegisterMonitoring.js
@@ -109,6 +109,8 @@ class RegisterMonitoring extends Component {
                     </Grid>
                     <Grid  item md-auto>
                         <TextField
+                            error = {this.state.error}
+                            required="true"   
                             id="descricaoTextfild"
                             label="Descrição"
                             placeholder="Descrição"

--- a/src/Components/__tests__/ProfileMonitor.test.js
+++ b/src/Components/__tests__/ProfileMonitor.test.js
@@ -17,7 +17,8 @@ firebase.initializeApp({
 var props = {
     match:{
         params:{
-            id_monitor:jest.fn()
+            id_monitor:jest.fn(),
+            id_tutoring_session:jest.fn()
         }  
     } 
   };

--- a/src/Components/__tests__/__snapshots__/EditMonitoring.test.js.snap
+++ b/src/Components/__tests__/__snapshots__/EditMonitoring.test.js.snap
@@ -35,15 +35,12 @@ exports[`Testing EditMonitoring component Test if EditMonitoring renders correct
   >
     <WithStyles(Grid)
       item={true}
-      xs={12}
+      md-auto={true}
     >
       <TextField
-        Maxrows="4"
         error=""
         id="name"
-        label="Nome"
-        margin="normal"
-        multiline={true}
+        label="Tema"
         onChange={[Function]}
         required="true"
         select={false}
@@ -53,16 +50,14 @@ exports[`Testing EditMonitoring component Test if EditMonitoring renders correct
     </WithStyles(Grid)>
     <WithStyles(Grid)
       item={true}
+      md-auto={true}
     >
       <TextField
-        Maxrows="4"
         error=""
         id="subject"
         label="Matéria"
         margin="normal"
-        multiline={true}
         onChange={[Function]}
-        placeholder=""
         required="true"
         select={false}
         value=""
@@ -71,20 +66,20 @@ exports[`Testing EditMonitoring component Test if EditMonitoring renders correct
     </WithStyles(Grid)>
     <WithStyles(Grid)
       item={true}
+      md-auto={true}
     >
       <TextField
-        Maxrows="4"
         error=""
         id="description"
         label="Descrição"
         margin="normal"
         multiline={true}
         onChange={[Function]}
-        placeholder=""
-        required="true"
+        placeholder="Descrição"
+        required={false}
         select={false}
         value=""
-        variant="standard"
+        variant="outlined"
       />
     </WithStyles(Grid)>
   </WithStyles(Grid)>

--- a/src/Components/__tests__/__snapshots__/EditMonitoring.test.js.snap
+++ b/src/Components/__tests__/__snapshots__/EditMonitoring.test.js.snap
@@ -41,8 +41,9 @@ exports[`Testing EditMonitoring component Test if EditMonitoring renders correct
         error=""
         id="name"
         label="Tema"
+        margin="normal"
         onChange={[Function]}
-        required={true}
+        required="true"
         select={false}
         value=""
         variant="standard"
@@ -57,8 +58,10 @@ exports[`Testing EditMonitoring component Test if EditMonitoring renders correct
         id="subject"
         label="Matéria"
         margin="normal"
+        multiline={true}
         onChange={[Function]}
-        required="true"
+        placeholder=""
+        required={true}
         select={false}
         value=""
         variant="standard"
@@ -75,7 +78,7 @@ exports[`Testing EditMonitoring component Test if EditMonitoring renders correct
         margin="normal"
         multiline={true}
         onChange={[Function]}
-        placeholder="Descrição"
+        placeholder=""
         required={false}
         select={false}
         value=""

--- a/src/Components/__tests__/__snapshots__/ProfileMonitor.test.js.snap
+++ b/src/Components/__tests__/__snapshots__/ProfileMonitor.test.js.snap
@@ -13,6 +13,7 @@ exports[`Testing ProfileTabMonitor component Test if ProfileTabMonitor renders c
     Object {
       "params": Object {
         "id_monitor": [MockFunction],
+        "id_tutoring_session": [MockFunction],
       },
     }
   }

--- a/src/Helpers/validates.js
+++ b/src/Helpers/validates.js
@@ -32,9 +32,9 @@ export const validatepasswordconfirm = user => {
 }
 
 export const validateRegisterMonitoring = Monitoring => {
-    const {name,subject} = Monitoring;
+    const {name,subject,description} = Monitoring;
     
-     if(!name  || !subject) return false;
+     if(!name  || !subject || !description) return false;
 
      return true;
     


### PR DESCRIPTION
## Issue resolvida

#  [[REFACTOR] Campos criar / editar monitoria](https://github.com/fga-eps-mds/2019.1-MaisMonitoria/issues/172)


## Comentário
Foi alterado os campos da pagina de editar monitoria para que ficasse semelhante aos campos de registrar uma nova monitoria. 
 
Registrar Monitoria:
![image](https://user-images.githubusercontent.com/48539765/59556385-35af6980-8f98-11e9-8c53-c9f7d8e7ad74.png)

Editar Monitoria:
![image](https://user-images.githubusercontent.com/48539765/59556440-f33a5c80-8f98-11e9-82ca-495bc1173d80.png)


