### PR TITLE
Us29 deletar monitoria

### DIFF
--- a/src/Components/Feed/ExpandedCard.js
+++ b/src/Components/Feed/ExpandedCard.js
@@ -5,6 +5,7 @@ import axios from 'axios';
 import AppBar from './AppBarWithBack';
 import './ExpandedCard.css'
 import Spinner from '../Loader/Spinner';
+import AlertDialog from '../SimpleModal/AlertDialog';
 
 import { ReactComponent as Logo } from '../../Assets/svg/telegram.svg';
 import { ReactComponent as Like } from '../../Assets/svg/like.svg';
@@ -202,10 +203,8 @@ class ExpandedCard extends React.Component {
                         {(this.state.id_monitor === this.state.id_user)?
                           <Grid container direction="row" justify="center" alignItems="center" >
                             <MuiThemeProvider  theme={theme}>
-                                <Grid item xs>
-                                    <Button style={{marginTop:40, marginLeft:-10}} component={Link} variant="contained" color="primary" >
-                                        Excluir
-                                    </Button>
+                                <Grid item xs style={{marginTop:40, marginLeft:-10}}>
+                                    <AlertDialog/>
                                 </Grid>
                                 <Grid item xs>
                                     <Button style={{marginTop:40, marginLeft:10}} component={Link} variant="contained" to={`/editmonitoring/${this.state.id_tutoring}`} color="primary">

--- a/src/Components/Feed/ExpandedCard.js
+++ b/src/Components/Feed/ExpandedCard.js
@@ -205,12 +205,21 @@ class ExpandedCard extends React.Component {
                                 
                             </MuiThemeProvider>: null }
                             
-                        {(this.state.id_monitor === this.state.id_user)? 
+                        {(this.state.id_monitor === this.state.id_user)?
+                          <Grid container direction="row" justify="center" alignItems="center" >
                             <MuiThemeProvider  theme={theme}>
-                                <Button style={{marginTop:40,marginLeft:50}} component={Link} variant="contained" to={`/editmonitoring/${this.state.id_tutoring}`} color="primary">
-                                    Editar
-                                </Button>
-                            </MuiThemeProvider>: null}                           
+                                <Grid item xs>
+                                    <Button style={{marginTop:40, marginLeft:-10}} component={Link} variant="contained" color="primary" >
+                                        Excluir
+                                    </Button>
+                                </Grid>
+                                <Grid item xs>
+                                    <Button style={{marginTop:40, marginLeft:10}} component={Link} variant="contained" to={`/editmonitoring/${this.state.id_tutoring}`} color="primary">
+                                        Editar
+                                    </Button>
+                                </Grid>
+                            </MuiThemeProvider>
+                            </Grid>  : null}                         
                         </Grid>
                     
                     </Grid>

--- a/src/Components/SimpleModal/AlertDialog.js
+++ b/src/Components/SimpleModal/AlertDialog.js
@@ -6,6 +6,10 @@ import DialogContent from '@material-ui/core/DialogContent';
 import DialogContentText from '@material-ui/core/DialogContentText';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import firebase from 'firebase';
+import axios from 'axios';
+import {success} from '../../Helpers/validates';
+import {withRouter} from 'react-router-dom';
 
 
 const theme = createMuiTheme({
@@ -23,45 +27,71 @@ const theme = createMuiTheme({
     },
   });
 
-export default function AlertDialog() {
-  const [open, setOpen] = React.useState(false);
+  
+class  AlertDialog extends React.Component {
 
-  function handleClickOpen() {
-    setOpen(true);
+  state = { 
+    open: false,
+    setOpen: false,
+  }
+  
+  delete_tutoring= ()=>{
+    var token= {};
+    var idTutoring = this.props.match.params.id_tutoring; 
+      token["id_tutoring"] = idTutoring;
+      console.log()
+    firebase.auth().currentUser.getIdToken().then(function(idToken){
+      token["access_token"] = idToken;
+     
+    });
+  
+    axios.post(process.env.REACT_APP_GATEWAY+"/delete_tutoring/", token)
+        .then(res => {
+          if(success(res)){
+            this.props.history.push('/Feed');
+          } 
+        });
+  }
+  handleClickOpen = ()=> {
+    this.setState({open: true});
   }
 
-  function handleClose() {
-    setOpen(false);
+  handleClose = ()=>{
+    this.setState({setOpen: false});
+    this.props.history.push('/Feed');
   }
-
-  return (
-    <div>
-        <MuiThemeProvider theme={theme}>
-            <Button variant="contained" color="primary" onClick={handleClickOpen}>
-                excluir
-            </Button>
-        </MuiThemeProvider>
-        <Dialog
-        open={open}
-        onClose={handleClose}
-        aria-labelledby="alert-dialog-title"
-        aria-describedby="alert-dialog-deion"
-        >
-            <DialogTitle id="alert-dialog-title">{"Excluir Monitoria?"}</DialogTitle>
-            <DialogContent>
-            <DialogContentText id="alert-dialog-deion">
-                Deseja realmente excluir a monitoria?
-            </DialogContentText>
-            </DialogContent>
-            <DialogActions>
-            <Button onClick={handleClose} color="primary">
-                cancelar
-            </Button>
-            <Button onClick={handleClose} color="primary" autoFocus>
-                excluir
-            </Button>
-            </DialogActions>
-      </Dialog>
-    </div>
-  );
+render(){
+    return (
+      <div>
+          <MuiThemeProvider theme={theme}>
+              <Button variant="contained" color="primary" onClick={this.handleClickOpen}>
+                  excluir
+              </Button>
+          </MuiThemeProvider>
+          <Dialog
+          open={this.state.open}
+          onClose={this.handleClose}
+          aria-labelledby="alert-dialog-title"
+          aria-describedby="alert-dialog-deion"
+          >
+              <DialogTitle id="alert-dialog-title">{"Excluir Monitoria?"}</DialogTitle>
+              <DialogContent>
+              <DialogContentText id="alert-dialog-deion">
+                  Deseja realmente excluir a monitoria?
+              </DialogContentText>
+              </DialogContent>
+              <DialogActions>
+              <Button onClick={this.handleClose} color="primary">
+                  cancelar
+              </Button>
+              <Button onClick={this.delete_tutoring} color="primary" autoFocus>
+                  excluir
+              </Button>
+              </DialogActions>
+        </Dialog>
+      </div>
+    );
+  }
 }
+
+export default withRouter(AlertDialog);

--- a/src/Components/SimpleModal/AlertDialog.js
+++ b/src/Components/SimpleModal/AlertDialog.js
@@ -39,7 +39,6 @@ class  AlertDialog extends React.Component {
     var token= {};
     var idTutoring = this.props.match.params.id_tutoring; 
       token["id_tutoring"] = idTutoring;
-      console.log()
     firebase.auth().currentUser.getIdToken().then(function(idToken){
       token["access_token"] = idToken;
      

--- a/src/Components/SimpleModal/AlertDialog.js
+++ b/src/Components/SimpleModal/AlertDialog.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+
+
+const theme = createMuiTheme({
+    palette: {
+      primary: { main: '#44a1f2' },
+      secondary: { main: '#fafafa' },
+    },
+    typography: { useNextVariants: false },
+    overrides: {
+        MuiButton: {
+          raisedPrimary: {
+            color: 'white',
+          },
+        },
+    },
+  });
+
+export default function AlertDialog() {
+  const [open, setOpen] = React.useState(false);
+
+  function handleClickOpen() {
+    setOpen(true);
+  }
+
+  function handleClose() {
+    setOpen(false);
+  }
+
+  return (
+    <div>
+        <MuiThemeProvider theme={theme}>
+            <Button variant="contained" color="primary" onClick={handleClickOpen}>
+                excluir
+            </Button>
+        </MuiThemeProvider>
+        <Dialog
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="alert-dialog-title"
+        aria-describedby="alert-dialog-deion"
+        >
+            <DialogTitle id="alert-dialog-title">{"Excluir Monitoria?"}</DialogTitle>
+            <DialogContent>
+            <DialogContentText id="alert-dialog-deion">
+                Deseja realmente excluir a monitoria?
+            </DialogContentText>
+            </DialogContent>
+            <DialogActions>
+            <Button onClick={handleClose} color="primary">
+                cancelar
+            </Button>
+            <Button onClick={handleClose} color="primary" autoFocus>
+                excluir
+            </Button>
+            </DialogActions>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/Components/__tests__/AlertDialog.js
+++ b/src/Components/__tests__/AlertDialog.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import { shallow } from 'enzyme';
-import ExpandedCard from '../Feed/ExpandedCard';
-import toJson from 'enzyme-to-json';
+import AlertDialog from '../SimpleModal/AlertDialog';
 import firebase from 'firebase';
+import {shallow} from 'enzyme';
 import renderer from 'react-test-renderer';
 import { MemoryRouter as Router } from 'react-router-dom';
+import toJson from 'enzyme-to-json';
 
 firebase.initializeApp({
   apiKey: '...',
@@ -15,24 +15,23 @@ firebase.initializeApp({
   messagingSenderId: '...',
 });
 
-let props = {
+let props={
     match:{
         params:{
-            id_tutoring: jest.fn()
-        }
-    }      
-  };
-const expandedcard= jest.fn();
+            id_tutoring:jest.fn()    
+    }}
+};
+const alertdialog= jest.fn();
 
-describe('Testing Add component', () => {
-    it('Test if Add renders correctly', () =>{
-        jest.fn()
-        const tree = shallow(<ExpandedCard {...props}/>);
+describe('Testing AlertDialog component', () => {
+    it('Test if AlertDialog renders correctly', () =>{
+        jest.fn();
+        const tree = shallow(<AlertDialog {...props}/>);
         expect(toJson(tree)).toMatchSnapshot();
     });
-    it('Test if Course renders correctly', () =>{
+    it('Test if AlertDialog renders correctly', () =>{
       const tree = renderer.create(
-        <Router><ExpandedCard expandedcard={expandedcard}/></Router>
+        <Router><AlertDialog alertdialog={alertdialog}/></Router>
         )
         expect(toJson(tree)).toMatchSnapshot()
     });

--- a/src/Components/__tests__/Feed.test.js
+++ b/src/Components/__tests__/Feed.test.js
@@ -17,7 +17,7 @@ firebase.initializeApp({
 const feed = jest.fn();
 
 
-  it('Test if Course renders correctly', () =>{
+  it('Test if Feed renders correctly', () =>{
     const tree = renderer.create(
       <Router><Feed feed={feed}/></Router>
       )

--- a/src/Components/__tests__/ProfileMonitor.test.js
+++ b/src/Components/__tests__/ProfileMonitor.test.js
@@ -22,8 +22,8 @@ var props = {
     } 
   };
 
-describe('Testing ProfileTabMonitor component', () => {
-    it('Test if ProfileTabMonitor renders correctly', () =>{
+describe('Testing ProfileMonitor component', () => {
+    it('Test if ProfileMonitor renders correctly', () =>{
         jest.fn()
         const tree = shallow(<ProfileMonitor {...props}/>);
         expect(toJson(tree)).toMatchSnapshot();

--- a/src/Components/__tests__/ProfileTabMonitor.test.js
+++ b/src/Components/__tests__/ProfileTabMonitor.test.js
@@ -21,7 +21,7 @@ let props = {
     tutoring:{
         map: jest.fn()
         
-    }      // You don't need to define the implementation if it's empty
+    }
   };
 
 describe('Testing ProfileTabMonitor component', () => {

--- a/src/Components/__tests__/__snapshots__/AlertDialog.js.snap
+++ b/src/Components/__tests__/__snapshots__/AlertDialog.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Testing AlertDialog component Test if AlertDialog renders correctly 1`] = `
+<Route>
+  <Component />
+</Route>
+`;
+
+exports[`Testing AlertDialog component Test if AlertDialog renders correctly 2`] = `undefined`;

--- a/src/Components/__tests__/__snapshots__/ExpandedCard.test.js.snap
+++ b/src/Components/__tests__/__snapshots__/ExpandedCard.test.js.snap
@@ -5,3 +5,5 @@ exports[`Testing Add component Test if Add renders correctly 1`] = `
   <Component />
 </Route>
 `;
+
+exports[`Testing Add component Test if Course renders correctly 1`] = `undefined`;

--- a/src/Components/__tests__/__snapshots__/Feed.test.js.snap
+++ b/src/Components/__tests__/__snapshots__/Feed.test.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Test if Course renders correctly 1`] = `undefined`;
+exports[`Test if Feed renders correctly 1`] = `undefined`;

--- a/src/Components/__tests__/__snapshots__/ProfileMonitor.test.js.snap
+++ b/src/Components/__tests__/__snapshots__/ProfileMonitor.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Testing ProfileTabMonitor component Test if ProfileTabMonitor renders correctly 1`] = `
+exports[`Testing ProfileMonitor component Test if ProfileMonitor renders correctly 1`] = `
 <Profile
   classes={
     Object {


### PR DESCRIPTION
## Issue resolvida

[[US29] Deletar monitoria](https://github.com/fga-eps-mds/2019.1-MaisMonitoria/issues/170)

## Comentário

Inicialmente foi criado um botão de excluir que aparece na monitoria , apenas para o usuário dono da monitoria. Ao clicar no botão de excluir é aberto component Dialog, para que o usuário tenha a opção de realmente excluir ou cancelar a operação, se a monitoria for excluída o usuário será redirecionado para o feed caso contrario será redirecionado para a monitoria. 

![image](https://user-images.githubusercontent.com/31708472/59649759-1eb87500-915a-11e9-8ae4-3ee8a0663c84.png)
Botão de excluir monitoria.

![image](https://user-images.githubusercontent.com/31708472/59649798-3abc1680-915a-11e9-8e15-6e7dfa7f27de.png)
Dialog de confirmação da ação.




 
